### PR TITLE
install from environment.yaml to resolve ambivalence

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ COMPAS wrapper for the Python bindings of OCC
 ## Installation
 
 ```bash
-conda create -n occ python=3.8 COMPAS compas_view2 pythonocc-core
+conda env create -f=environment.yml
 conda activate occ
-pip install -e .
 ```
 
 ## Scripts

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,17 @@
+name: occ
+channels:
+  - conda-forge # pythonocc-core
+  - defaults
+dependencies:
+  - python=3.8
+  - anaconda
+  - pip
+  - COMPAS
+#  - compas_view2 # could not find a channel that hosts this
+  - pythonocc-core
+  - cython # compas_view2, really
+  - python.app # compas_view2, really
+  - pip:
+    # note extra points for -e developer install, yeaaaah
+    - -r file:requirements.txt # pip & conda happily go together
+    - -r file:requirements-dev.txt # since its early days, installing the dev deps seems sensible

--- a/environment.yml
+++ b/environment.yml
@@ -4,13 +4,10 @@ channels:
   - defaults
 dependencies:
   - python=3.8
-  - anaconda
   - pip
   - COMPAS
 #  - compas_view2 # could not find a channel that hosts this
   - pythonocc-core
-  - cython # compas_view2, really
-  - python.app # compas_view2, really
   - pip:
     # note extra points for -e developer install, yeaaaah
     - -r file:requirements.txt # pip & conda happily go together

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+git+https://github.com/jf---/AFEM@pythonocc
+git+https://github.com/tpaviot/pythonocc-utils
+git+https://github.com/compas-dev/compas_view2.git#egg=compas_view2

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -1,0 +1,5 @@
+def test_install():
+    from afem.geometry import distance
+    from compas_view2.app import App
+    from OCCUtils.edge import Edge
+


### PR DESCRIPTION
installing `compas_occ` is somewhat ambivalent as of now:

- it's not obvious which channels are required to complete the install
  - environment.yaml solves this
- compas_viewer2 is not installable from compas
- AFEM and pythonocc-utils are pretty key to get going, source installs are added to requirements.txt

Also, `conda` can handle installation of `pip` requirements.txt, so this approach seems a little more solid.
Finally, you can update your env by `conda env update -f environment.yml` which is convenient
