### PR TITLE
fix exception of curve.closest_point if no orthogonal projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,5 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed input parameters of `new_nurbscurve_from_step`.
 * Fixed error in attributes of empty curve.
 * Fixed error in parameter list of `new_nurbscurve` plugin.
+* Fixed exception handling in `compas_occ.geometry.NurbsCurve.closest_point` if no orthogonal projection possible.
 
 ### Removed

--- a/src/compas_occ/geometry/curves/nurbs.py
+++ b/src/compas_occ/geometry/curves/nurbs.py
@@ -586,7 +586,8 @@ class OCCNurbsCurve(NurbsCurve):
         return Frame(Point.from_occ(point), Vector.from_occ(uvec), Vector.from_occ(vvec))
 
     def closest_point(self, point: Point, return_parameter: bool = False) -> Union[Point, Tuple[Point, float]]:
-        """Compute the closest point on the curve to a given point.
+        """Compute the closest point on the curve to a given point. 
+        If an orthogonal projection is not possible, the start or end point is returned, whichever is closer.
 
         Parameters
         ----------

--- a/src/compas_occ/geometry/curves/nurbs.py
+++ b/src/compas_occ/geometry/curves/nurbs.py
@@ -7,7 +7,7 @@ from compas.geometry import Transformation
 from compas.geometry import Frame
 from compas.geometry import Circle
 from compas.geometry import Box
-from compas.geometry._core.distance import distance_point_point
+from compas.geometry import distance_point_point
 from compas.utilities import linspace
 
 from compas.geometry import NurbsCurve
@@ -607,18 +607,20 @@ class OCCNurbsCurve(NurbsCurve):
             if return_parameter:
                 parameter = projector.LowerDistanceParameter()
 
-        except RuntimeError:
-            start = self.start
-            end = self.end
+        except RuntimeError as e:
+            if e.args[0] == 'StdFail_NotDoneGeomAPI_ProjectPointOnCurve::NearestPoint raised from method NearestPoint of class GeomAPI_ProjectPointOnCurve':
 
-            if distance_point_point(point, start) <= distance_point_point(point, end):
-                point = start
-                if return_parameter:
-                    parameter = self.occ_curve.FirstParameter()
-            else:
-                point = end
-                if return_parameter:
-                    parameter = self.occ_curve.LastParameter()
+                start = self.start
+                end = self.end
+
+                if distance_point_point(point, start) <= distance_point_point(point, end):
+                    point = start
+                    if return_parameter:
+                        parameter = self.occ_curve.FirstParameter()
+                else:
+                    point = end
+                    if return_parameter:
+                        parameter = self.occ_curve.LastParameter()
 
         if not return_parameter:
             return point

--- a/src/compas_occ/geometry/curves/nurbs.py
+++ b/src/compas_occ/geometry/curves/nurbs.py
@@ -586,7 +586,7 @@ class OCCNurbsCurve(NurbsCurve):
         return Frame(Point.from_occ(point), Vector.from_occ(uvec), Vector.from_occ(vvec))
 
     def closest_point(self, point: Point, return_parameter: bool = False) -> Union[Point, Tuple[Point, float]]:
-        """Compute the closest point on the curve to a given point. 
+        """Compute the closest point on the curve to a given point.
         If an orthogonal projection is not possible, the start or end point is returned, whichever is closer.
 
         Parameters

--- a/src/compas_occ/geometry/curves/nurbs.py
+++ b/src/compas_occ/geometry/curves/nurbs.py
@@ -609,7 +609,7 @@ class OCCNurbsCurve(NurbsCurve):
                 parameter = projector.LowerDistanceParameter()
 
         except RuntimeError as e:
-            if e.args[0] == 'StdFail_NotDoneGeomAPI_ProjectPointOnCurve::NearestPoint raised from method NearestPoint of class GeomAPI_ProjectPointOnCurve':
+            if e.args[0].startswith('StdFail_NotDoneGeomAPI_ProjectPointOnCurve::NearestPoint'):
 
                 start = self.start
                 end = self.end
@@ -622,6 +622,8 @@ class OCCNurbsCurve(NurbsCurve):
                     point = end
                     if return_parameter:
                         parameter = self.occ_curve.LastParameter()
+            else:
+                raise
 
         if not return_parameter:
             return point


### PR DESCRIPTION
if no orthogonal projection possible, use start or end point, whichever is closer

<!-- Thank you for your pull request!  -->
<!-- Please start by describing your change in a few sentences. -->
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [ ] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
