### PR TITLE
Brep plugin

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,3 +2,4 @@
 
 - Tom Van Mele <<van.mele@arch.ethz.ch>> [@brgcode](https://github.com/brgcode), [@tomvanmele](https://github.com/tomvanmele)
 - Lotte Aldinger <<aldinger@arch.ethz.ch>> [@lottilotte](https://github.com/lottilotte)
+- Chen Kasirer <<kasirer@arch.ethz.ch>> [@chenkasirer](https://github.com/chenkasirer)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added `BRep` plugins for `compas.geometry.Brep`
+
 ### Changed
+
+* Fixed Matrix indexing bug in `BRep.frame`
 
 ### Removed
 

--- a/src/compas_occ/__init__.py
+++ b/src/compas_occ/__init__.py
@@ -40,4 +40,5 @@ __all__ = ["HOME", "DATA", "DOCS", "TEMP"]
 __all_plugins__ = [
     'compas_occ.geometry.curves',
     'compas_occ.geometry.surfaces',
+    'compas_occ.brep',
 ]

--- a/src/compas_occ/brep/__init__.py
+++ b/src/compas_occ/brep/__init__.py
@@ -19,8 +19,25 @@ Classes
     BRepFace
 
 """
+from compas.plugins import plugin
+
 from .brepvertex import BRepVertex  # noqa: F401
 from .brepedge import BRepEdge  # noqa: F401
 from .breploop import BRepLoop  # noqa: F401
 from .brepface import BRepFace  # noqa: F401
 from .brep import BRep  # noqa: F401
+
+
+@plugin(category="factories", requires=["OCC"])
+def new_brep(*args, **kwargs):
+    return object.__new__(BRep)
+
+
+@plugin(category="factories", requires=["OCC"])
+def from_brep(*args, **kwargs):
+    return BRep.from_shape(*args, **kwargs)
+
+
+@plugin(category="factories", requires=["OCC"])
+def from_box(*args, **kwargs):
+    return BRep.from_box(*args, **kwargs)

--- a/src/compas_occ/brep/brep.py
+++ b/src/compas_occ/brep/brep.py
@@ -389,11 +389,13 @@ class BRep(Data):
     @property
     def frame(self) -> compas.geometry.Frame:
         location = self.occ_shape.Location()
-        transformation = location.Transformation()
-        T = Transformation(
-            matrix=[[transformation.Value(i, j) for j in range(4)] for i in range(4)]
-        )
-        frame = Frame.from_transformation(T)
+        t = location.Transformation()
+
+        # transformation.Value is a 1-based 3x4 matrix
+        rows, columns = 3, 4
+        matrix = [[t.Value(i, j) for j in range(1, columns + 1)] for i in range(1, rows + 1)]
+        matrix.append([0.0, 0.0, 0.0, 1.0])  # COMPAS wants a 4x4 matrix
+        frame = Frame.from_transformation(Transformation(matrix))
         return frame
 
     @property

--- a/src/compas_occ/brep/brep.py
+++ b/src/compas_occ/brep/brep.py
@@ -3,7 +3,6 @@ from typing import List, Tuple, Union
 import compas.geometry
 import compas.datastructures
 
-from compas.data import Data
 from compas.geometry import Frame
 from compas.geometry import Transformation
 from compas.geometry import Translation

--- a/src/compas_occ/brep/brep.py
+++ b/src/compas_occ/brep/brep.py
@@ -10,6 +10,7 @@ from compas.geometry import Translation
 from compas.geometry import Point
 from compas.geometry import Polyline
 from compas.geometry import Polygon
+from compas.geometry import Brep as BrepPluggable
 from compas.datastructures import Mesh
 
 from OCC.Extend.DataExchange import read_step_file
@@ -83,7 +84,7 @@ from compas_occ.brep import BRepLoop
 from compas_occ.brep import BRepFace
 
 
-class BRep(Data):
+class BRep(BrepPluggable):
     """Class for Boundary Representation of geometric entities.
 
     Attributes
@@ -147,6 +148,11 @@ class BRep(Data):
     >>> E = A & B
 
     """
+
+    # this makes de-serialization backend-agnostic.
+    # The deserializing type is determined by plugin availability when de-serializing
+    # regardless of the context available when serializing.
+    __class__ = BrepPluggable
 
     def __init__(self) -> None:
         super().__init__()

--- a/src/compas_occ/brep/brep.py
+++ b/src/compas_occ/brep/brep.py
@@ -289,11 +289,11 @@ class BRep(BrepPluggable):
 
     @property
     def is_manifold(self) -> bool:
-        pass
+        raise NotImplementedError
 
     @property
     def is_surface(self) -> bool:
-        pass
+        raise NotImplementedError
 
     # ==============================================================================
     # Geometric Components

--- a/tests/brep/test_brep.py
+++ b/tests/brep/test_brep.py
@@ -1,0 +1,23 @@
+from pytest import fixture
+
+from compas.geometry import Box
+
+from compas_occ.brep import BRep
+
+
+@fixture
+def box():
+    return Box.from_width_height_depth(5., 5., 5.,)
+
+
+def test_create_brep():
+    _ = BRep()
+
+
+def test_brep_from_box(box):
+    _ = BRep.from_box(box)
+
+
+def test_brep_from_box_properties(box):
+    brep = BRep.from_box(box)
+    _ = brep.frame

--- a/tests/brep/test_brep.py
+++ b/tests/brep/test_brep.py
@@ -1,6 +1,7 @@
 from pytest import fixture
 
-from compas.geometry import Box
+from compas.geometry import Box, Frame
+from compas.geometry import close
 
 from compas_occ.brep import BRep
 
@@ -11,13 +12,16 @@ def box():
 
 
 def test_create_brep():
-    _ = BRep()
+    brep = BRep()
+    assert brep is not None
 
 
 def test_brep_from_box(box):
-    _ = BRep.from_box(box)
+    box_brep = BRep.from_box(box)
+    assert close(box_brep.volume, box.volume)
+    assert close(box_brep.area, box.area)
 
 
 def test_brep_from_box_properties(box):
     brep = BRep.from_box(box)
-    _ = brep.frame
+    assert brep.frame == Frame.worldXY()


### PR DESCRIPTION
**Edit:**
- **Tests fail because `compas` is installed from `conda-forge` and new `Brep` pluggable is only available in the unreleased COMPAS `main`. Have to wait for next release?**

This PR adds `compas_occ` plugins to the new pluggable `compas.geometry.Brep`.
There's also a small bugfix and some open issues.

The pluggable `Brep` allows writing (somewhat) context agnostic code when working with a `Brep`, this is realized using the COMPAS plugin system and some backends (currently Rhino).

```python
>>> from compas.geometry import Brep, Box
>>> Brep.from_box(Box.from_width_height_depth(5,5,5))
<compas_occ.brep.brep.BRep object at 0x00000198E97052B0>
```

This also allows serializing a `Brep` created in `compas_occ` and using is in e.g. Rhino 
```python
# in compas_occ
from compas.data json_dump
from compas.geometry import Box, Brep

path = r"..."

brep = Brep.from_box(Box.from_width_height_depth(5,5,5))

>>> type(brep)
<class 'compas_occ.brep.brep.BRep'>

json_dump(brep, path)
```

```python
# in Rhino/Grasshopper
from compas.data json_load

path = r"..."

brep = json_load(path)

>>> type(brep)
<class 'compas_rhino.geometry.brep.RhinoBrep'>

```

Known issues:
- Interoperability with Rhino is fragile. OCC surfaces are serialized as different kinds of shapes whereas Rhino can currently only deal with NURBS surfaces.

### What type of change is this?

- [x] Bug fix in a **backwards-compatible** manner.
- [x] New feature in a **backwards-compatible** manner.
- [ ] Breaking change: bug fix or new feature that involve incompatible API changes.
- [ ] Other (e.g. doc update, configuration, etc)

### Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I added a line to the `CHANGELOG.md` file in the `Unreleased` section under the most fitting heading (e.g. `Added`, `Changed`, `Removed`).
- [x] I ran all tests on my computer and it's all green (i.e. `invoke test`).
- [x] I ran lint on my computer and there are no errors (i.e. `invoke lint`).
- [ ] I added new functions/classes and made them available on a second-level import, e.g. `compas.datastructures.Mesh`.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added necessary documentation (if appropriate)
